### PR TITLE
make the addon work in zero downtime deployment environments

### DIFF
--- a/config/cookie-byte.php
+++ b/config/cookie-byte.php
@@ -2,6 +2,14 @@
 
     return [
 
+        /**
+         * This specifies the asset container, which is used for all asset fields in the Cookie Byte config.
+         */
         'asset_container' => 'assets',
+
+        /**
+         * This specifies the directory, in which the addon will save its Control Panel configuration file.
+         */
+        'config_dirname' => base_path("content"),
 
     ];

--- a/src/Configuration/CookieByteConfig.php
+++ b/src/Configuration/CookieByteConfig.php
@@ -2,13 +2,13 @@
 
 namespace DDM\CookieByte\Configuration;
 
-use Illuminate\Http\Request;
-use Statamic\Facades\File;
-use Statamic\Facades\Site;
-use Statamic\Facades\YAML;
-use Statamic\Fields\Blueprint;
-use Statamic\Fields\Fields;
+use DDM\CookieByte\CookieByte;
 use Statamic\Support\Arr;
+use Statamic\Facades\File;
+use Statamic\Facades\YAML;
+use Statamic\Fields\Fields;
+use Illuminate\Http\Request;
+use Statamic\Fields\Blueprint;
 
 /**
  * Class CookieByteConfig
@@ -27,8 +27,8 @@ class CookieByteConfig
 	{
 		$this->currentLocale = $locale;
 		$this->blueprint = \Statamic\Facades\Blueprint::make()->setContents(ConfigBlueprint::getBlueprint());
-        $this->configPath = storage_path("statamic/addons/cookie-byte/cookie_byte_" . $this->currentLocale . ".yaml");
-		$this->configData = YAML::parse(File::disk()->get($this->configPath));
+		$this->configPath = CookieByte::getConfigurationPath($this->currentLocale);
+		$this->configData = CookieByte::getConfigurationData($this->currentLocale);
 	}
 
 	/**

--- a/src/Configuration/CookieByteConfig.php
+++ b/src/Configuration/CookieByteConfig.php
@@ -27,7 +27,7 @@ class CookieByteConfig
 	{
 		$this->currentLocale = $locale;
 		$this->blueprint = \Statamic\Facades\Blueprint::make()->setContents(ConfigBlueprint::getBlueprint());
-		$this->configPath = base_path("content/cookie_byte_" . $this->currentLocale . ".yaml");
+        $this->configPath = storage_path("statamic/addons/cookie-byte/cookie_byte_" . $this->currentLocale . ".yaml");
 		$this->configData = YAML::parse(File::disk()->get($this->configPath));
 	}
 

--- a/src/CookieByte.php
+++ b/src/CookieByte.php
@@ -43,7 +43,7 @@ class CookieByte
 	 */
 	public static function getConfigurationData($locale): array
 	{
-		return YAML::file(base_path(self::getConfigurationFile($locale)))->parse();
+        return YAML::file(self::getConfigurationFile($locale))->parse();
 	}
 
 	/**
@@ -55,7 +55,7 @@ class CookieByte
 	 */
 	public static function getConfigurationFile($locale): string
 	{
-		return base_path("content/cookie_byte_" . $locale . ".yaml");
+        return storage_path("statamic/addons/cookie-byte/cookie_byte_" . $locale . ".yaml");
 	}
 
 	/**

--- a/src/CookieByte.php
+++ b/src/CookieByte.php
@@ -3,6 +3,7 @@
 namespace DDM\CookieByte;
 
 use Statamic\Facades\YAML;
+use Illuminate\Support\Str;
 use Statamic\Licensing\LicenseManager;
 
 /**
@@ -43,7 +44,7 @@ class CookieByte
 	 */
 	public static function getConfigurationData($locale): array
 	{
-        return YAML::file(self::getConfigurationFile($locale))->parse();
+        return YAML::file(self::getConfigurationPath($locale))->parse();
 	}
 
 	/**
@@ -53,9 +54,19 @@ class CookieByte
 	 *
 	 * @return string
 	 */
-	public static function getConfigurationFile($locale): string
+	public static function getConfigurationPath($locale): string
 	{
-        return storage_path("statamic/addons/cookie-byte/cookie_byte_" . $locale . ".yaml");
+		return self::getConfigurationDirname() . "cookie_byte_$locale.yaml";
+	}
+
+	/**
+	 * Returns the configuration directory path.
+	 * 
+	 * @return string
+	 */
+	public static function getConfigurationDirname(): string
+	{
+		return Str::finish(config('cookie-byte.config_dirname', base_path("content")), '/');
 	}
 
 	/**

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -116,8 +116,8 @@ class ServiceProvider extends AddonServiceProvider
 		parent::bootPublishables();
 
 		$this->publishes([
-			__DIR__ . '/../content/cookie_byte_en_US.default.yaml' => CookieByte::getConfigurationFile("en_US"),
-			__DIR__ . '/../content/cookie_byte_de_DE.default.yaml' => CookieByte::getConfigurationFile("de_DE"),
+			__DIR__ . '/../content/cookie_byte_en_US.default.yaml' => CookieByte::getConfigurationPath("en_US"),
+			__DIR__ . '/../content/cookie_byte_de_DE.default.yaml' => CookieByte::getConfigurationPath("de_DE"),
 		], CookieByte::VENDOR_DEFAULT_SETTINGS_KEY);
 
 		$this->publishes([


### PR DESCRIPTION
**Problem:**
`base_path()` returns a path relative to the applications root directory. Without any customizations (such as custom stache paths in Statamic) this will be overwritten on every deploy in environments where every release has it's own directory.

**Solution:**
Either extend the configuration to be able to alter the storage path for the addon or use `storage_path()` instead of `base_path()`, because `/storage` has to be persisted between releases anyways. In my experience `/storage/statamic/addons/[ADDON]` is the de facto standard for storing addon data.
