### PR TITLE
Changes saving configuration from locale to handle for multi site

### DIFF
--- a/config/cookie-byte.php
+++ b/config/cookie-byte.php
@@ -12,4 +12,12 @@
          */
         'config_dirname' => base_path("content"),
 
+        /**
+         * This specifies the value to save the configuration under.
+		 *
+		 * Allowed options:
+		 * - \DDM\CookieByte\CookieByte::HANDLE_IDENTIFIER | Uses the site handle to save. Useful if you have multiple domains.
+		 * - \DDM\CookieByte\CookieByte::LOCALE_IDENTIFIER | Uses the site locale. Recommended if you only translate the text.
+         */
+        'site_identifier_type' => \DDM\CookieByte\CookieByte::LOCALE_IDENTIFIER,
     ];

--- a/src/Configuration/CookieByteConfig.php
+++ b/src/Configuration/CookieByteConfig.php
@@ -18,17 +18,17 @@ use Statamic\Fields\Blueprint;
 class CookieByteConfig
 {
 
-	protected $currentHandle;
+	protected $currentIdentifier;
 	protected $blueprint;
 	protected $configPath;
 	protected $configData;
 
-	public function __construct($handle)
+	public function __construct($identifier)
 	{
-		$this->currentHandle = $handle;
+		$this->currentIdentifier = $identifier;
 		$this->blueprint = \Statamic\Facades\Blueprint::make()->setContents(ConfigBlueprint::getBlueprint());
-		$this->configPath = CookieByte::getConfigurationPath($this->currentHandle);
-		$this->configData = CookieByte::getConfigurationData($this->currentHandle);
+		$this->configPath = CookieByte::getConfigurationPath($this->currentIdentifier);
+		$this->configData = CookieByte::getConfigurationData($this->currentIdentifier);
 	}
 
 	/**

--- a/src/Configuration/CookieByteConfig.php
+++ b/src/Configuration/CookieByteConfig.php
@@ -18,17 +18,17 @@ use Statamic\Fields\Blueprint;
 class CookieByteConfig
 {
 
-	protected $currentLocale;
+	protected $currentHandle;
 	protected $blueprint;
 	protected $configPath;
 	protected $configData;
 
-	public function __construct($locale)
+	public function __construct($handle)
 	{
-		$this->currentLocale = $locale;
+		$this->currentHandle = $handle;
 		$this->blueprint = \Statamic\Facades\Blueprint::make()->setContents(ConfigBlueprint::getBlueprint());
-		$this->configPath = CookieByte::getConfigurationPath($this->currentLocale);
-		$this->configData = CookieByte::getConfigurationData($this->currentLocale);
+		$this->configPath = CookieByte::getConfigurationPath($this->currentHandle);
+		$this->configData = CookieByte::getConfigurationData($this->currentHandle);
 	}
 
 	/**

--- a/src/CookieByte.php
+++ b/src/CookieByte.php
@@ -38,30 +38,30 @@ class CookieByte
 	/**
 	 * Returns the configuration file data as an array.
 	 *
-	 * @param $locale configuration's locale
+	 * @param $handle configuration's handle
 	 *
 	 * @return array
 	 */
-	public static function getConfigurationData($locale): array
+	public static function getConfigurationData($handle): array
 	{
-        return YAML::file(self::getConfigurationPath($locale))->parse();
+        return YAML::file(self::getConfigurationPath($handle))->parse();
 	}
 
 	/**
 	 * Returns the configuration file path.
 	 *
-	 * @param $locale configuration's locale
+	 * @param $handle configuration's handle
 	 *
 	 * @return string
 	 */
-	public static function getConfigurationPath($locale): string
+	public static function getConfigurationPath($handle): string
 	{
-		return self::getConfigurationDirname() . "cookie_byte_$locale.yaml";
+		return self::getConfigurationDirname() . "cookie_byte_$handle.yaml";
 	}
 
 	/**
 	 * Returns the configuration directory path.
-	 * 
+	 *
 	 * @return string
 	 */
 	public static function getConfigurationDirname(): string

--- a/src/CookieByte.php
+++ b/src/CookieByte.php
@@ -2,9 +2,11 @@
 
 namespace DDM\CookieByte;
 
+use Statamic\Facades\Site;
 use Statamic\Facades\YAML;
 use Illuminate\Support\Str;
 use Statamic\Licensing\LicenseManager;
+use function config;
 
 /**
  * Global definitions and routines.
@@ -35,28 +37,31 @@ class CookieByte
 	public const VENDOR_VIEWS_KEY = self::NAMESPACE . '-views';
 	public const VENDOR_LANGUAGES_KEY = self::NAMESPACE . '-lang';
 
+	public const LOCALE_IDENTIFIER = 'locale';
+	public const HANDLE_IDENTIFIER = 'handle';
+
 	/**
 	 * Returns the configuration file data as an array.
 	 *
-	 * @param $handle configuration's handle
+	 * @param $identifier configuration's identifier
 	 *
 	 * @return array
 	 */
-	public static function getConfigurationData($handle): array
+	public static function getConfigurationData($identifier): array
 	{
-        return YAML::file(self::getConfigurationPath($handle))->parse();
+        return YAML::file(self::getConfigurationPath($identifier))->parse();
 	}
 
 	/**
 	 * Returns the configuration file path.
 	 *
-	 * @param $handle configuration's handle
+	 * @param $identifier configuration's identifier
 	 *
 	 * @return string
 	 */
-	public static function getConfigurationPath($handle): string
+	public static function getConfigurationPath($identifier): string
 	{
-		return self::getConfigurationDirname() . "cookie_byte_$handle.yaml";
+		return self::getConfigurationDirname() . "cookie_byte_$identifier.yaml";
 	}
 
 	/**
@@ -91,6 +96,28 @@ class CookieByte
 	public static function getCpTranslation($translationKey): string
 	{
 		return __(CookieByte::NAMESPACE . '::cp.' . $translationKey);
+	}
+
+	public static function getCurrentSiteIdentifier(): string
+	{
+		switch (config('cookie-byte.site_identifier_type', self::LOCALE_IDENTIFIER)) {
+			case self::HANDLE_IDENTIFIER:
+				return Site::current()->handle();
+			case self::LOCALE_IDENTIFIER:
+			default:
+				return Site::current()->locale();
+		}
+	}
+
+	public static function getSelectedSiteIdentifier(): string
+	{
+		switch (config('cookie-byte.site_identifier_type', self::LOCALE_IDENTIFIER)) {
+			case self::HANDLE_IDENTIFIER:
+				return Site::selected()->handle();
+			case self::LOCALE_IDENTIFIER:
+			default:
+				return Site::selected()->locale();
+		}
 	}
 
 	/**

--- a/src/Http/Controllers/SettingsController.php
+++ b/src/Http/Controllers/SettingsController.php
@@ -5,7 +5,6 @@ namespace DDM\CookieByte\Http\Controllers;
 use DDM\CookieByte\Configuration\CookieByteConfig;
 use DDM\CookieByte\CookieByte;
 use Illuminate\Http\Request;
-use Statamic\Facades\Site;
 use Statamic\Facades\User;
 use Statamic\Http\Controllers\CP\CpController;
 use Statamic\StaticCaching\Cacher;
@@ -52,7 +51,7 @@ class SettingsController extends CpController
 
 	public function getConfig()
 	{
-		return new CookieByteConfig(Site::selected()->handle());
+		return new CookieByteConfig(CookieByte::getSelectedSiteIdentifier());
 	}
 
 	protected function isStaticCachingEnabled()

--- a/src/Http/Controllers/SettingsController.php
+++ b/src/Http/Controllers/SettingsController.php
@@ -52,7 +52,7 @@ class SettingsController extends CpController
 
 	public function getConfig()
 	{
-		return new CookieByteConfig(Site::selected()->locale());
+		return new CookieByteConfig(Site::selected()->handle());
 	}
 
 	protected function isStaticCachingEnabled()

--- a/src/Tags/CookieCover.php
+++ b/src/Tags/CookieCover.php
@@ -6,7 +6,6 @@ use DDM\CookieByte\Configuration\CookieByteConfig;
 use DDM\CookieByte\CookieByte;
 use DDM\CookieByte\Exceptions\CookieCoverException;
 use Statamic\Facades\Asset;
-use Statamic\Facades\Site;
 use Statamic\Tags\Tags;
 
 /**
@@ -21,7 +20,7 @@ class CookieCover extends Tags
 
 	public function __construct()
 	{
-		$this->config = new CookieByteConfig(Site::current()->handle());
+		$this->config = new CookieByteConfig(CookieByte::getCurrentSiteIdentifier());
 	}
 
 	/**

--- a/src/Tags/CookieCover.php
+++ b/src/Tags/CookieCover.php
@@ -21,7 +21,7 @@ class CookieCover extends Tags
 
 	public function __construct()
 	{
-		$this->config = new CookieByteConfig(Site::current()->locale());
+		$this->config = new CookieByteConfig(Site::current()->handle());
 	}
 
 	/**

--- a/src/Tags/CookieModal.php
+++ b/src/Tags/CookieModal.php
@@ -19,7 +19,7 @@ class CookieModal extends Tags
 
 	public function __construct()
 	{
-		$this->config = new CookieByteConfig(Site::current()->locale());
+		$this->config = new CookieByteConfig(Site::current()->handle());
 	}
 
 	public function index()

--- a/src/Tags/CookieModal.php
+++ b/src/Tags/CookieModal.php
@@ -4,7 +4,6 @@ namespace DDM\CookieByte\Tags;
 
 use DDM\CookieByte\Configuration\CookieByteConfig;
 use DDM\CookieByte\CookieByte;
-use Statamic\Facades\Site;
 use Statamic\Tags\Tags;
 
 /**
@@ -19,7 +18,7 @@ class CookieModal extends Tags
 
 	public function __construct()
 	{
-		$this->config = new CookieByteConfig(Site::current()->handle());
+		$this->config = new CookieByteConfig(CookieByte::getCurrentSiteIdentifier());
 	}
 
 	public function index()


### PR DESCRIPTION
This MR changes the way the configuration is saved. Instead of saving to locale it uses the site handle. This enables the ability to configure different cookies for each site in Statamic.

This MR is a proposal. Would love to hear the original authors thoughts and remarks on this approach. 